### PR TITLE
Replaced log display panel on the home page(index.html) with ckeditor display box

### DIFF
--- a/Olog/public_html/index.html
+++ b/Olog/public_html/index.html
@@ -353,9 +353,10 @@
 									</div>
 								</div>
 
-								<div class="log_body">
+								<div class="log_body" style="padding: 25px">
 									<!-- <textarea disabled="disabled" id="log_description"></textarea>-->
-									<textarea id="log_description" disabled></textarea>
+									<textarea id="log_description" disabled ></textarea> 
+									<script src="static/ckeditor/ckeditor.js"></script>
 								</div>
 
 								<div class="log_attachments">

--- a/Olog/public_html/static/ckeditor/plugins/timestamp/plugin.js
+++ b/Olog/public_html/static/ckeditor/plugins/timestamp/plugin.js
@@ -2,7 +2,6 @@ CKEDITOR.plugins.add( 'timestamp', {
     icon: 'timestamp',
     init: function( editor ) {
         //Plugin logic goes here.
-        console.log("timestamp init called");
 	editor.addCommand( 'insertTimestamp', {
     	    exec: function( editor ) {
             var now = new Date();

--- a/Olog/public_html/static/js/helper.js
+++ b/Olog/public_html/static/js/helper.js
@@ -96,40 +96,6 @@ function returnTimeFilterTimestamp(from, to) {
 	return [currentSeconds - fromSeconds, currentSeconds - toSeconds];
 }
 
-/*
- * Retun first X words from the string.
- * @param {type} string input string
- * @param {type} count how many of words do we want to return
- * @returns {String} First X words
- */
-function returnFirstXWords(string, count){
-	//string = textHTML(string);
-	var words = string.split(" ");
-	var summary = "";
-	var append = "";
-
-	if (count > words.length) {
-		count = words.length;
-
-	} else {
-		append = " ...";
-	}
-
-	if(words.length > 0){
-		summary = words[0];
-
-		if(words.length > 1){
-			for(i=1; i<count; i++) {
-				summary += " " + words[i];
-			}
-		}
-		return summary + append;
-
-	}else {
-		return summary;
-	}
-}
-
 /**
  * Format the date according to format specified in configuration.js file
  * @param {type} input datetime string
@@ -350,12 +316,16 @@ function imageToSize(str, size, border){
     return div.innerHTML;
 }    
 
-//get the text out of HTML string
-function textHTML(str){
+//get the text out of HTML string and return first n words
+function textHTML(str, count){
     var div = document.createElement("div");
     div.innerHTML = str;
     var text = div.textContent || div.innerText || "";
-    return text;
+    var words = text.split(/\s+/);
+    if (count < words.length)
+        return words.slice(0,count).join(" ") + "...";
+    else
+        return text ;
 }
 
 /**

--- a/Olog/public_html/static/js/rest.js
+++ b/Olog/public_html/static/js/rest.js
@@ -277,7 +277,20 @@ function showLog(log, id){
 	log_desc = log.description;
 
 	//Replace textarea with CKEDITOR display panel, remove toolbar to make it read-only.
-	if (!CKEDITOR.instances.log_description) CKEDITOR.replace("log_description", {toolbar: [], allowedContent: true, height: '50vh'});
+	if (!CKEDITOR.instances.log_description) {
+		var editor = CKEDITOR.replace("log_description", {toolbar: [], allowedContent: true, height: '50vh'});
+
+		//Override internal click event handler to allow mouse click to work on external URL links.
+		editor.on( 'contentDom', function() {
+		    var editable = editor.editable();
+		    editable.attachListener( editable, 'click', function( evt ) {
+	                var link = new CKEDITOR.dom.elementPath( evt.data.getTarget(), this ).contains( 'a' );
+        	        if ( link && evt.data.$.button != 2 && link.isReadOnly() ) {
+            	 	    window.open( link.getAttribute( 'href' ) );
+        	        }
+		    }, null, null, 15 );
+		} );
+	}
 	CKEDITOR.instances.log_description.setData(log_desc);
 	
 	$("#log_owner").html(log.owner);
@@ -656,7 +669,7 @@ function prepareParentAndChildren(i, children, prepend, logOwners) {
 		}
 		// Build customized Log object
 		var childItem = {
-			description: textHTML(returnFirstXWords(child.description, 40)),
+			description: textHTML(child.description, 20),
 			owner: logOwners[child.id + '_1'],
 			modifiedOwner: child.owner,
 			createdDate: formatDate(child.createdDate),

--- a/Olog/public_html/static/js/rest.js
+++ b/Olog/public_html/static/js/rest.js
@@ -276,13 +276,10 @@ function showLog(log, id){
 	globalLogId = id;
 	log_desc = log.description;
 
-    //escape the text for any html elements entered
-	//$("#log_description").text(escapeHTML(desc));
-	$("#log_description").text(log_desc);
-	setMarkdown("log_description");
-	//$("#log_description").attr("rows", lines.length);
-
-
+	//Replace textarea with CKEDITOR display panel, remove toolbar to make it read-only.
+	if (!CKEDITOR.instances.log_description) CKEDITOR.replace("log_description", {toolbar: [], allowedContent: true, height: '50vh'});
+	CKEDITOR.instances.log_description.setData(log_desc);
+	
 	$("#log_owner").html(log.owner);
 	$("#log_date").html(formatDate(log.modifiedDate));
 	$("#log_date").html(formatDate(log.modifiedDate));
@@ -577,7 +574,7 @@ function prepareParentAndChildren(i, children, prepend, logOwners) {
 
 	// Build customized Log object
 	var newItem = {
-		description: textHTML(returnFirstXWords(item.description, 40)),
+		description: textHTML(item.description, 20),
 		owner: originalOwner,
 		modifiedOwner: item.owner,
 		createdDate: formatDate(item.createdDate),


### PR DESCRIPTION
Replaced log display panel on the home page(index.html) with ckeditor display box(read only), the old display panel was having problems while showing tables.
The middle partition on the home page used to show short descriptions by using first 40 html words of log data and extracting text words from it.
Now it will show first 20 text words. Function returnFirstXWords() no longer required now.